### PR TITLE
Adding username

### DIFF
--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -1510,6 +1510,17 @@ a=sendrecv
                 the IdP.
               </t>
               <t>
+                An application can optionally provide a user identifier when
+                specifying an IdP.  This value is a hint that the IdP can use to
+                select amongst multiple identities, or to avoid providing
+                assertions for unwanted identities.  The user identifier hint is
+                passed to the IdP in a <spanx style="verb">username</spanx>
+                field alongside the <spanx style="verb">message</spanx>.  The
+                <spanx style="verb">username</spanx> is a string that has no
+                meaning to any entity other than the IdP, it can contain any
+                data the IdP needs in order to correctly generate an assertion.
+              </t>
+              <t>
                 A successful response to a "SIGN" message contains a message
                 field which is a JS dictionary consisting of two fields:
               </t>
@@ -1543,7 +1554,8 @@ PeerConnection -> IdP proxy:
      "type":"SIGN",
      "id":1,
      "origin":"https://calling-service.example.com/",
-     "message":"abcdefghijklmnopqrstuvwyz"
+     "message": "abcdefghijklmnopqrstuvwyz",
+     "username": "bob"
   }
 
 IdPProxy -> PeerConnection:


### PR DESCRIPTION
So the API has a username parameter, which could be handy if you are concurrently logged in a couple of ways, or you didn't want to have a particular user identity leaked.  Or just for a general control channel when generating an assertion.

However, we don't have a way to pass this information down to the IdP.  That presents a problem: "message" is defined to be the blob that contains the fingerprints.  We can't use that for two reasons: it's supposed to be opaque (it's for browser to talk to other browser), and we don't really want this information being carried in the assertion.

Two options seem fairly obvious:
1. bump the opaque blob down another level:

``` json
{
  "type": "SIGN", "id": "12", "origin": "https://example.org",
  "message": {
    "content": "...the binary blob...",
    "username": "user@example.com"
  }
}
```
1. Add some more parameters at the next level up:

``` json
{
  "type": "SIGN", "id": "12", "origin": "https://example.org",
  "message": "...the binary blob...",
  "username": "user@example.com"
}
```

The latter looks marginally better to the IdP, so I've included that one.
